### PR TITLE
add keyboard access to search and copy/paste behaviour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11959,9 +11959,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "sass": "1.21.0",
     "sass-loader": "7.1.0",
     "style-loader": "0.23.1",
-    "typescript": "4.4.4",
+    "typescript": "5.2.2",
     "webpack": "4.33.0",
     "webpack-cli": "3.3.3",
     "webpack-dev-server": "3.7.1",

--- a/src/new.tsx
+++ b/src/new.tsx
@@ -105,8 +105,8 @@ function Charming() {
 
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key == "/") {
-        openSearch();
         e.preventDefault();
+        openSearch();
       }
     };
 
@@ -115,6 +115,8 @@ function Charming() {
       const selection = window.getSelection();
       if (selection && selection.type == "Range") return;
 
+      e.preventDefault();
+
       // Need to use window.location.hash, not just location.hash, so that the closure captures
       // window (and thus location.hash is updated) rather than capturing location (where hash would
       // not be updated)
@@ -122,7 +124,6 @@ function Charming() {
       const points = getHashPoints(window.location.hash, [0]);
 
       e.clipboardData?.setData("text/plain", pointsToString(points));
-      e.preventDefault();
     };
 
     const onPaste = (e: ClipboardEvent) => {
@@ -130,6 +131,8 @@ function Charming() {
       // either case
       const text = e.clipboardData?.getData("text/plain");
       if (!text) return;
+
+      e.preventDefault();
 
       const firstBreak = getNextClusterBreak(data, text, null);
       if (!firstBreak) return;
@@ -150,8 +153,6 @@ function Charming() {
         setSearchQuery(text);
         openSearch();
       }
-
-      e.preventDefault();
     };
 
     const addListeners = () => {

--- a/src/new.tsx
+++ b/src/new.tsx
@@ -358,8 +358,8 @@ function Search({
 
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key == "Escape") {
-      close();
       e.preventDefault();
+      close();
     }
   };
 

--- a/src/new.tsx
+++ b/src/new.tsx
@@ -102,6 +102,8 @@ function Charming() {
   React.useEffect(() => {
     // Data is required to determine grapheme cluster breaks in pasted strings
     if (!data) return;
+    // Keyboard interaction only applies when viewing the map
+    if (searchOpen) return;
 
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key == "/") {
@@ -155,25 +157,16 @@ function Charming() {
       }
     };
 
-    const addListeners = () => {
-      window.addEventListener("keydown", onKeyDown);
-      window.addEventListener("copy", onCopy);
-      window.addEventListener("paste", onPaste);
-    };
-    const removeListeners = () => {
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("copy", onCopy);
+    window.addEventListener("paste", onPaste);
+
+    return () => {
       window.removeEventListener("keydown", onKeyDown);
       window.removeEventListener("copy", onCopy);
       window.removeEventListener("paste", onPaste);
     };
-
-    if (!searchOpen) {
-      addListeners();
-    } else {
-      removeListeners();
-    }
-
-    return removeListeners;
-  }, [searchOpen, data]);
+  }, [data]);
 
   return (
     <div className="Charming">

--- a/src/new.tsx
+++ b/src/new.tsx
@@ -77,6 +77,11 @@ function Charming() {
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
 
+  const openSearch = () => {
+    setSearchOpen(true);
+    setSearchEverOpened(true);
+  };
+
   const location = useLocation();
   const points = getHashPoints(location.hash, [0]);
 
@@ -93,16 +98,35 @@ function Charming() {
     }
   }, [data, points]);
 
+  React.useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key == "/") {
+        openSearch();
+        e.preventDefault();
+      }
+    };
+
+    const addListeners = () => {
+      window.addEventListener("keydown", onKeyDown);
+    };
+    const removeListeners = () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+
+    if (!searchOpen) {
+      addListeners();
+    } else {
+      removeListeners();
+    }
+
+    return removeListeners;
+  }, [searchOpen, data]);
+
   return (
     <div className="Charming">
       <DataContext.Provider value={data}>
         <PointsContext.Provider value={points}>
-          <Detail
-            search={() => {
-              setSearchOpen(true);
-              setSearchEverOpened(true);
-            }}
-          />
+          <Detail search={openSearch} />
           <Map />
           {searchEverOpened && (
             <Search
@@ -286,6 +310,13 @@ function Search({
 
   useEffect(() => void input.current!.focus(), [hidden]);
 
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key == "Escape") {
+      close();
+      e.preventDefault();
+    }
+  };
+
   return (
     <div className="Search" hidden={hidden}>
       <div className="toolbar">
@@ -297,6 +328,7 @@ function Search({
           autoFocus={true}
           value={query}
           onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={onKeyDown}
           placeholder="try “em” or “69” or “🏳️‍🌈”"
         />
       </div>


### PR DESCRIPTION
🐶

- adds keyboard access to search through '/' key
  - search can also be dismissed with escape
- copy copies the current point/points to the clipboard (if no other text on the page is selected)
- paste either:
  - jumps to the point/points from the clipboard, if the clipboard contains only one grapheme cluster
  - otherwise, performs a search for the full clipboard contents

this fixes #21 and #14 :3