### PR TITLE
pre-select text in search bar when opening

### DIFF
--- a/src/new.tsx
+++ b/src/new.tsx
@@ -364,7 +364,10 @@ function Search({
     }
   }, [data, query]);
 
-  useEffect(() => void input.current!.focus(), [hidden]);
+  useEffect(() => {
+    input.current!.focus();
+    input.current!.select();
+  }, [hidden]);
 
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key == "Escape") {


### PR DESCRIPTION
not sure if you actually wanna merge this one, but it was quick to knock up so i did it anyway

since i use charming as my emoji picker these days, i often want to search for two or more distinct emoji in quick succession. this means that i:
1. press `/` to open the search bar
2. type the name of the first emoji
3. click the relevant result
4. press `^C` to copy the emoji
5. press `/` to re-open the search bar
6. **delete the previous query with `^A`, `[backspace]` or equivalent**
7. repeat steps 2 through 6

as you would expect, i often forget step 6 and end up with `dogcat` in the search bar and a confused look on my face.

**this change selects the existing content of the textbox when search is opened, such that typing another query overwrites the previous one.** the old behaviour is still "accessible" in the sense that you can press right arrow to move to the end of the field.